### PR TITLE
Fix the builds jarDiffXML location

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -80,7 +80,7 @@
           depends="compileDiffXML"
           description="packages all classes into a jar">
 
-          <jar jarfile="${build.dir}/diffxml.jar" basedir="${build.dir}/"/>
+          <jar jarfile="${lib.dir}/diffxml.jar" basedir="${build.dir}/"/>
     <antcall target="cleanClasses"/>
 
   </target>


### PR DESCRIPTION
jarDiffXML was building to build/diffxml.jar which causes an error. Also the scripts are looking for it in lib/diffxml.jar so I updated the build file to put it there instead